### PR TITLE
feat: implement rider accept/reject orders and delivery step buttons …

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -5,8 +5,8 @@ Options -Indexes
 Options -MultiViews
 
 # ── Error pages ───────────────────────────────────────────
-ErrorDocument 404 /food/swiftbite_php_starter/404.php
-ErrorDocument 403 /food/swiftbite_php_starter/404.php
+ErrorDocument 404 /food/404.php
+ErrorDocument 403 /food/404.php
 
 # ── PHP settings ─────────────────────────────────────────
 php_flag display_errors off

--- a/actions/rider_respond_order.php
+++ b/actions/rider_respond_order.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * GDODS-46 — Rider Accept or Reject an Assigned Order
+ * Returns JSON. Called via AJAX from delivery/dashboard.php
+ */
+session_start();
+include('../core/config.php');
+include('../core/db.php');
+include('../core/csrf.php');
+include('../core/notification_helper.php');
+
+header('Content-Type: application/json');
+
+// Auth check
+if (!isset($_SESSION['user_id'])) {
+    echo json_encode(['success' => false, 'message' => 'Please login first.']); exit;
+}
+
+// CSRF check
+if (!validateCsrfToken($_POST['csrf_token'] ?? '')) {
+    echo json_encode(['success' => false, 'message' => 'Invalid security token.']); exit;
+}
+
+// Role check — only delivery partners
+$roleStmt = $pdo->prepare("SELECT role, name FROM users WHERE id = ? LIMIT 1");
+$roleStmt->execute([$_SESSION['user_id']]);
+$rider = $roleStmt->fetch(PDO::FETCH_ASSOC);
+
+if (!$rider || $rider['role'] !== 'delivery_partner') {
+    echo json_encode(['success' => false, 'message' => 'Access denied.']); exit;
+}
+
+$order_id  = (int)($_POST['order_id'] ?? 0);
+$action    = $_POST['action'] ?? ''; // 'accept' or 'reject'
+$rider_id  = (int)$_SESSION['user_id'];
+
+if ($order_id <= 0 || !in_array($action, ['accept', 'reject'], true)) {
+    echo json_encode(['success' => false, 'message' => 'Invalid request.']); exit;
+}
+
+try {
+    // Fetch the order — must be assigned to THIS rider with status 'assigned'
+    $stmt = $pdo->prepare("
+        SELECT * FROM orders
+        WHERE id = ? AND assigned_rider_id = ? AND status = 'assigned'
+        LIMIT 1
+    ");
+    $stmt->execute([$order_id, $rider_id]);
+    $order = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$order) {
+        echo json_encode(['success' => false, 'message' => 'Order not found or already processed.']); exit;
+    }
+
+    $orderLabel = '#' . str_pad($order_id, 5, '0', STR_PAD_LEFT);
+
+    if ($action === 'accept') {
+        // Accept → move to confirmed
+        $pdo->prepare("UPDATE orders SET status = 'confirmed', updated_at = NOW() WHERE id = ?")
+            ->execute([$order_id]);
+
+        // Notify the customer
+        addNotification(
+            $pdo, (int)$order['user_id'], 'order_status',
+            'Rider Accepted Your Order!',
+            'Great news! ' . htmlspecialchars($rider['name']) . ' has accepted order ' . $orderLabel . ' and is heading to the restaurant.',
+            '<i class="fa-solid fa-motorcycle" style="color:#ff4f00"></i>',
+            null,
+            SITE_BASE_URL . '/user/order_details.php?id=' . $order_id
+        );
+
+        echo json_encode(['success' => true, 'action' => 'accept', 'message' => 'Order accepted! Head to the restaurant.']);
+
+    } else {
+        // Reject → clear rider assignment, back to pending
+        $pdo->prepare("
+            UPDATE orders
+            SET status = 'pending',
+                assigned_rider_id = NULL,
+                delivery_partner_name = NULL,
+                delivery_partner_phone = NULL,
+                updated_at = NOW()
+            WHERE id = ?
+        ")->execute([$order_id]);
+
+        // Notify the customer that we're finding another rider
+        addNotification(
+            $pdo, (int)$order['user_id'], 'order_status',
+            'Finding Another Rider',
+            'Your order ' . $orderLabel . ' is being reassigned to another rider. Sorry for the wait!',
+            '<i class="fa-solid fa-hourglass-half" style="color:#f59e0b"></i>',
+            null,
+            SITE_BASE_URL . '/user/order_details.php?id=' . $order_id
+        );
+
+        echo json_encode(['success' => true, 'action' => 'reject', 'message' => 'Order rejected and returned to queue.']);
+    }
+
+} catch (Exception $e) {
+    echo json_encode(['success' => false, 'message' => 'Something went wrong. Please try again.']);
+}

--- a/actions/update_order_status.php
+++ b/actions/update_order_status.php
@@ -29,7 +29,7 @@ $status = trim((string) ($_POST['status'] ?? ''));
 $deliveryPartnerName = sanitize($_POST['delivery_partner_name'] ?? '');
 $deliveryPartnerPhone = sanitize($_POST['delivery_partner_phone'] ?? '');
 
-$allowedStatuses = ['pending', 'confirmed', 'preparing', 'out_for_delivery', 'delivered', 'cancelled'];
+$allowedStatuses = ['pending', 'assigned', 'confirmed', 'preparing', 'out_for_delivery', 'delivered', 'cancelled'];
 if ($order_id <= 0 || !in_array($status, $allowedStatuses, true)) {
     $_SESSION['delivery_error'] = 'Invalid order or status.';
     header('Location: ' . ($_SERVER['HTTP_REFERER'] ?? '../delivery/dashboard.php'));

--- a/core/config.php
+++ b/core/config.php
@@ -18,7 +18,7 @@ define('DB_CHARSET', 'utf8mb4');
 // ── Site ───────────────────────────────────────────────────
 define('SITE_NAME',     'SwiftBite');
 define('SITE_TAGLINE',  'Food Delivery, Reinvented');
-define('SITE_BASE_URL', '/food/swiftbite_php_starter'); // no trailing slash
+define('SITE_BASE_URL', '/food'); // no trailing slash
 
 // ── Upload limits ──────────────────────────────────────────
 define('MAX_UPLOAD_MB', 2);

--- a/core/rider_assignment_helper.php
+++ b/core/rider_assignment_helper.php
@@ -71,13 +71,13 @@ function assignNearestRider($pdo, $order_id, $addressString = '') {
         }
         
         if ($nearestRider && $minDist < 50) { // Only assign if within 50km (sanity check)
-            // 4. Assign the rider
+            // 4. Assign the rider — status set to 'assigned' so rider can accept/reject
             $assignStmt = $pdo->prepare("
-                UPDATE orders 
-                SET assigned_rider_id = ?, 
-                    delivery_partner_name = ?, 
+                UPDATE orders
+                SET assigned_rider_id = ?,
+                    delivery_partner_name = ?,
                     delivery_partner_phone = ?,
-                    status = 'confirmed' 
+                    status = 'assigned'
                 WHERE id = ?
             ");
             $assignStmt->execute([
@@ -86,6 +86,21 @@ function assignNearestRider($pdo, $order_id, $addressString = '') {
                 $nearestRider['phone'],
                 $order_id
             ]);
+
+            // Notify the rider of the new assignment
+            if (function_exists('addNotification')) {
+                addNotification(
+                    $pdo,
+                    $nearestRider['id'],
+                    'order_assigned',
+                    'New Order Assigned!',
+                    'Order #' . str_pad($order_id, 5, '0', STR_PAD_LEFT) . ' has been assigned to you. Accept or reject it from your dashboard.',
+                    '<i class="fa-solid fa-motorcycle" style="color:#ff4f00"></i>',
+                    null,
+                    '/food/delivery/dashboard.php'
+                );
+            }
+
             return true;
         }
         

--- a/delivery/dashboard.php
+++ b/delivery/dashboard.php
@@ -798,7 +798,7 @@ const miniMaps = {};
         }
 
         simBtn.disabled = true;
-        simBtn.textContent = '<i class="fa-solid fa-hourglass-half" style="color:#f59e0b"></i> Loading route...';
+        simBtn.innerHTML = '<i class="fa-solid fa-hourglass-half" style="color:#f59e0b"></i> Loading route...';
 
         // Stop page auto-refresh during simulation
         clearTimeout(refreshTimeout);
@@ -846,10 +846,10 @@ const miniMaps = {};
             if (step >= total) {
                 clearInterval(activeSimulations[orderId]);
                 delete activeSimulations[orderId];
-                simBtn.textContent  = '<i class="fa-solid fa-circle-check" style="color:#22c55e"></i> Delivered!';
+                simBtn.innerHTML    = '<i class="fa-solid fa-circle-check" style="color:#22c55e"></i> Delivered!';
                 simBtn.disabled     = true;
                 simBar.style.width  = '100%';
-                simText.textContent = '<i class="fa-solid fa-circle-check" style="color:#22c55e"></i> Simulation complete — rider arrived!';
+                simText.innerHTML   = '<i class="fa-solid fa-circle-check" style="color:#22c55e"></i> Simulation complete — rider arrived!';
                 return;
             }
 
@@ -879,7 +879,7 @@ const miniMaps = {};
             // Update progress bar
             const pct = Math.round((step / (total - 1)) * 100);
             simBar.style.width  = pct + '%';
-            simText.textContent = `<i class="fa-solid fa-motorcycle"></i> Simulating... ${pct}% (${step + 1}/${total} points)`;
+            simText.innerHTML = `<i class="fa-solid fa-motorcycle"></i> Simulating... ${pct}% (${step + 1}/${total} points)`;
             step++;
         }
 
@@ -956,14 +956,14 @@ document.querySelectorAll('.btn-toggle-tracking').forEach(btn => {
 
                     const now = new Date().toLocaleTimeString();
                     if (data.success) {
-                        document.getElementById('track-sub-' + orderId).textContent =
+                        document.getElementById('track-sub-' + orderId).innerHTML =
                             `<i class="fa-solid fa-circle-check" style="color:#22c55e"></i> Sent at ${now} · ${lat}, ${lng} · ±${acc}m`;
                     } else {
-                        document.getElementById('track-sub-' + orderId).textContent =
+                        document.getElementById('track-sub-' + orderId).innerHTML =
                             `<i class="fa-solid fa-triangle-exclamation" style="color:#f59e0b"></i> Server error at ${now}: ${data.message}`;
                     }
                 } catch(e) {
-                    document.getElementById('track-sub-' + orderId).textContent =
+                    document.getElementById('track-sub-' + orderId).innerHTML =
                         `<i class="fa-solid fa-triangle-exclamation" style="color:#f59e0b"></i> Network error — will retry on next movement`;
                 }
             },
@@ -1000,8 +1000,8 @@ function setTrackingState(orderId, state, title, sub) {
     if (!banner) return;
     banner.className = 'live-tracking-banner ' + state;
     document.getElementById('track-dot-' + orderId).className = 'tracking-dot ' + (state === 'active' ? 'green' : (state === 'error' ? 'red' : ''));
-    document.getElementById('track-title-' + orderId).textContent = title;
-    document.getElementById('track-sub-' + orderId).textContent = sub;
+    document.getElementById('track-title-' + orderId).innerHTML = title;
+    document.getElementById('track-sub-' + orderId).innerHTML = sub;
 }
 
 // ── Availability Toggle Logic ──

--- a/delivery/dashboard.php
+++ b/delivery/dashboard.php
@@ -20,9 +20,11 @@ $flash_success = $_SESSION['delivery_success'] ?? '';
 $flash_error   = $_SESSION['delivery_error']   ?? '';
 unset($_SESSION['delivery_success'], $_SESSION['delivery_error']);
 
+$rider_id = (int)$_SESSION['user_id'];
+
 // Stats
 $statsRow = $pdo->query("SELECT
-    COUNT(CASE WHEN status IN ('pending','confirmed','preparing','out_for_delivery') THEN 1 END) AS active_count,
+    COUNT(CASE WHEN status IN ('assigned','confirmed','preparing','out_for_delivery') THEN 1 END) AS active_count,
     COUNT(CASE WHEN status = 'out_for_delivery' THEN 1 END) AS in_transit,
     COUNT(CASE WHEN status = 'delivered' AND DATE(updated_at) = CURDATE() THEN 1 END) AS delivered_today
     FROM orders")->fetch(PDO::FETCH_ASSOC);
@@ -33,16 +35,30 @@ $stats = [
     'delivered' => (int)($statsRow['delivered_today'] ?? 0),
 ];
 
-// Active orders (all non-delivered, non-cancelled)
-$activeOrders = $pdo->query("
-    SELECT o.*, 
+// GDODS-46: New assignments waiting for this rider to accept/reject
+$assignedOrders = $pdo->prepare("
+    SELECT o.*,
            COALESCE(GROUP_CONCAT(oi.food_name SEPARATOR ', '), '') AS item_names,
            COUNT(oi.id) AS item_count
     FROM orders o
     LEFT JOIN order_items oi ON oi.order_id = o.id
-    WHERE o.status IN ('pending','confirmed','preparing','out_for_delivery')
+    WHERE o.status = 'assigned' AND o.assigned_rider_id = ?
     GROUP BY o.id
-    ORDER BY FIELD(o.status,'out_for_delivery','preparing','confirmed','pending'), o.created_at ASC
+    ORDER BY o.created_at ASC
+");
+$assignedOrders->execute([$rider_id]);
+$assignedOrders = $assignedOrders->fetchAll(PDO::FETCH_ASSOC);
+
+// GDODS-51: Active orders (confirmed/preparing/out_for_delivery)
+$activeOrders = $pdo->query("
+    SELECT o.*,
+           COALESCE(GROUP_CONCAT(oi.food_name SEPARATOR ', '), '') AS item_names,
+           COUNT(oi.id) AS item_count
+    FROM orders o
+    LEFT JOIN order_items oi ON oi.order_id = o.id
+    WHERE o.status IN ('confirmed','preparing','out_for_delivery')
+    GROUP BY o.id
+    ORDER BY FIELD(o.status,'out_for_delivery','preparing','confirmed'), o.created_at ASC
 ")->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <!DOCTYPE html>
@@ -206,6 +222,26 @@ $activeOrders = $pdo->query("
         .sim-progress-bar-fill { height: 100%; background: linear-gradient(90deg, #6c47ff, #a78bfa); width: 0%; transition: width 0.4s ease; border-radius: 3px; }
         .sim-status-text { font-size: 0.78rem; color: #a78bfa; font-weight: 600; }
 
+        /* ── GDODS-46: Assigned Order Card ── */
+        .assigned-section { margin-bottom: 28px; }
+        .assigned-badge { display: inline-flex; align-items: center; gap: 6px; background: rgba(255,184,48,0.2); border: 1px solid rgba(255,184,48,0.4); color: #f0b429; padding: 4px 12px; border-radius: 999px; font-size: 0.78rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.5px; animation: pulse-border 1.5s infinite; }
+        .order-card.new-assignment { border-color: rgba(255,184,48,0.6); box-shadow: 0 0 0 2px rgba(255,184,48,0.15); }
+        .assignment-actions { padding: 16px 22px; border-top: 1px solid rgba(255,255,255,0.06); display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+        .btn-accept { background: linear-gradient(135deg, #1a7a34, #34c759); color: #fff; border: none; padding: 14px; border-radius: 14px; font-weight: 800; font-size: 0.95rem; cursor: pointer; width: 100%; font-family: 'DM Sans', sans-serif; transition: all .2s; }
+        .btn-accept:hover { opacity: 0.88; transform: translateY(-1px); }
+        .btn-reject { background: rgba(255,59,48,0.15); color: #ff3b30; border: 1px solid rgba(255,59,48,0.35); padding: 14px; border-radius: 14px; font-weight: 800; font-size: 0.95rem; cursor: pointer; width: 100%; font-family: 'DM Sans', sans-serif; transition: all .2s; }
+        .btn-reject:hover { background: rgba(255,59,48,0.3); }
+        .btn-accept:disabled, .btn-reject:disabled { opacity: 0.4; pointer-events: none; }
+
+        /* ── GDODS-51: Delivery Step Buttons ── */
+        .step-actions { padding: 14px 22px; border-top: 1px solid rgba(255,255,255,0.06); }
+        .step-label-text { font-size: 0.75rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; color: #8b6a44; margin-bottom: 10px; }
+        .btn-step { width: 100%; padding: 13px; border: none; border-radius: 14px; font-weight: 800; font-size: 0.9rem; cursor: pointer; font-family: 'DM Sans', sans-serif; transition: all .2s; display: flex; align-items: center; justify-content: center; gap: 8px; }
+        .btn-step:hover { opacity: 0.88; transform: translateY(-1px); }
+        .btn-step:disabled { opacity: 0.4; pointer-events: none; }
+        .btn-pickup   { background: linear-gradient(135deg, #007aff, #5ac8fa); color: #fff; }
+        .btn-deliver  { background: linear-gradient(135deg, #1a7a34, #34c759); color: #fff; }
+
         /* Live Tracking Banner */
         .live-tracking-banner {
             margin: 0 22px 14px;
@@ -354,7 +390,67 @@ $activeOrders = $pdo->query("
             </div>
         </div>
 
-        <!-- Orders -->
+        <!-- GDODS-46: New Assignments -->
+        <?php if (!empty($assignedOrders)): ?>
+        <div class="assigned-section">
+            <div class="section-head" style="margin-bottom:12px;">
+                <h2 class="section-title" style="color:#f0b429;"><i class="fa-solid fa-bell"></i> New Assignments</h2>
+                <span class="assigned-badge"><i class="fa-solid fa-circle-exclamation"></i> Action Required</span>
+            </div>
+            <div class="orders-grid">
+                <?php foreach ($assignedOrders as $order): ?>
+                <div class="order-card new-assignment" id="assigned-card-<?php echo (int)$order['id']; ?>">
+                    <div class="card-header">
+                        <div>
+                            <div class="order-id">Order #<?php echo str_pad($order['id'], 5, '0', STR_PAD_LEFT); ?></div>
+                            <div class="order-time"><?php echo date('M d • h:i A', strtotime($order['created_at'])); ?></div>
+                        </div>
+                        <span class="assigned-badge"><i class="fa-solid fa-hourglass-half"></i> Awaiting Response</span>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-section">
+                            <div class="field-label">Customer</div>
+                            <div class="field-value"><?php echo htmlspecialchars($order['customer_name']); ?></div>
+                            <div class="field-label" style="margin-top:12px;">Phone</div>
+                            <div class="field-value">
+                                <a href="tel:<?php echo htmlspecialchars($order['customer_phone']); ?>" style="color:var(--orange);text-decoration:none;">
+                                    <i class="fa-solid fa-phone"></i> <?php echo htmlspecialchars($order['customer_phone']); ?>
+                                </a>
+                            </div>
+                            <div class="field-label" style="margin-top:12px;">Items (<?php echo $order['item_count']; ?>)</div>
+                            <div class="field-value"><?php echo htmlspecialchars(mb_strimwidth($order['item_names'], 0, 60, '...')); ?></div>
+                        </div>
+                        <div class="card-section">
+                            <div class="field-label">Delivery Address</div>
+                            <div class="field-value"><?php echo htmlspecialchars($order['delivery_address']); ?>, <?php echo htmlspecialchars($order['delivery_city']); ?></div>
+                            <div class="field-label" style="margin-top:12px;">Payment</div>
+                            <div class="field-value"><?php echo strtoupper(htmlspecialchars($order['payment_method'])); ?></div>
+                            <div class="field-label" style="margin-top:12px;">Order Total</div>
+                            <div class="field-value highlight">Rs. <?php echo number_format((float)$order['total'], 2); ?></div>
+                        </div>
+                    </div>
+                    <!-- Accept / Reject Buttons -->
+                    <div class="assignment-actions">
+                        <button class="btn-accept"
+                            data-order-id="<?php echo (int)$order['id']; ?>"
+                            data-action="accept"
+                            data-csrf="<?php echo htmlspecialchars(generateCsrfToken()); ?>">
+                            <i class="fa-solid fa-circle-check"></i> Accept Order
+                        </button>
+                        <button class="btn-reject"
+                            data-order-id="<?php echo (int)$order['id']; ?>"
+                            data-action="reject"
+                            data-csrf="<?php echo htmlspecialchars(generateCsrfToken()); ?>">
+                            <i class="fa-solid fa-circle-xmark"></i> Reject Order
+                        </button>
+                    </div>
+                </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+        <?php endif; ?>
+
+        <!-- GDODS-51: Active Orders Queue -->
         <div class="section-head">
             <h2 class="section-title"><i class="fa-solid fa-box"></i> Orders Queue</h2>
             <a class="refresh-btn" href="dashboard.php">🔄 Refresh</a>
@@ -372,7 +468,6 @@ $activeOrders = $pdo->query("
                     $isPriority = $order['status'] === 'out_for_delivery';
                     $statusClass = 's-' . $order['status'];
                     $statusLabels = [
-                        'pending'          => ['<i class="fa-solid fa-hourglass-half" style="color:#f59e0b"></i>', 'Pending'],
                         'confirmed'        => ['👍', 'Confirmed'],
                         'preparing'        => ['🧑‍🍳', 'Preparing'],
                         'out_for_delivery' => ['<i class="fa-solid fa-motorcycle"></i>', 'Out for Delivery'],
@@ -390,11 +485,11 @@ $activeOrders = $pdo->query("
                         <div class="status-pill <?php echo $statusClass; ?>"><?php echo $sIcon . ' ' . $sLabel; ?></div>
                     </div>
 
-                    <!-- Rider + Status form inline fields -->
+                    <!-- Rider Name & Phone -->
                     <form action="../actions/update_order_status.php" method="POST">
                         <?php echo csrfInput(); ?>
                         <input type="hidden" name="order_id" value="<?php echo (int)$order['id']; ?>">
-
+                        <input type="hidden" name="status" value="<?php echo htmlspecialchars($order['status']); ?>">
                         <div class="form-inline">
                             <div>
                                 <label class="inp-label">Your Name</label>
@@ -408,21 +503,36 @@ $activeOrders = $pdo->query("
                                     value="<?php echo htmlspecialchars($order['delivery_partner_phone'] ?? $rider['phone'] ?? ''); ?>"
                                     placeholder="98XXXXXXXX" required>
                             </div>
-                            <div>
-                                <label class="inp-label">Update Status</label>
-                                <select class="sel" name="status" required>
-                                    <?php foreach (['pending','confirmed','preparing','out_for_delivery','delivered','cancelled'] as $s): ?>
-                                        <option value="<?php echo $s; ?>" <?php echo $order['status'] === $s ? 'selected' : ''; ?>>
-                                            <?php echo ucwords(str_replace('_', ' ', $s)); ?>
-                                        </option>
-                                    <?php endforeach; ?>
-                                </select>
-                            </div>
-                            <div style="display:flex;align-items:flex-end;">
-                                <button type="submit" class="btn-save">💾 Save Status</button>
-                            </div>
                         </div>
                     </form>
+
+                    <!-- GDODS-51: Step Buttons -->
+                    <div class="step-actions">
+                        <div class="step-label-text"><i class="fa-solid fa-route"></i> Update Delivery Status</div>
+                        <?php if (in_array($order['status'], ['confirmed', 'preparing'])): ?>
+                            <form action="../actions/update_order_status.php" method="POST">
+                                <?php echo csrfInput(); ?>
+                                <input type="hidden" name="order_id" value="<?php echo (int)$order['id']; ?>">
+                                <input type="hidden" name="status" value="out_for_delivery">
+                                <input type="hidden" name="delivery_partner_name" value="<?php echo htmlspecialchars($order['delivery_partner_name'] ?? $rider['name']); ?>">
+                                <input type="hidden" name="delivery_partner_phone" value="<?php echo htmlspecialchars($order['delivery_partner_phone'] ?? $rider['phone'] ?? ''); ?>">
+                                <button type="submit" class="btn-step btn-pickup">
+                                    <i class="fa-solid fa-bag-shopping"></i> Mark as Picked Up
+                                </button>
+                            </form>
+                        <?php elseif ($order['status'] === 'out_for_delivery'): ?>
+                            <form action="../actions/update_order_status.php" method="POST">
+                                <?php echo csrfInput(); ?>
+                                <input type="hidden" name="order_id" value="<?php echo (int)$order['id']; ?>">
+                                <input type="hidden" name="status" value="delivered">
+                                <input type="hidden" name="delivery_partner_name" value="<?php echo htmlspecialchars($order['delivery_partner_name'] ?? $rider['name']); ?>">
+                                <input type="hidden" name="delivery_partner_phone" value="<?php echo htmlspecialchars($order['delivery_partner_phone'] ?? $rider['phone'] ?? ''); ?>">
+                                <button type="submit" class="btn-step btn-deliver">
+                                    <i class="fa-solid fa-circle-check"></i> Mark as Delivered
+                                </button>
+                            </form>
+                        <?php endif; ?>
+                    </div>
 
                     <!-- Customer & Order Info -->
                     <div class="card-body">
@@ -535,6 +645,74 @@ $activeOrders = $pdo->query("
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 
 <script>
+// ══════════════════════════════════════════════
+// GDODS-46: Accept / Reject assigned orders
+// ══════════════════════════════════════════════
+document.querySelectorAll('.btn-accept, .btn-reject').forEach(btn => {
+    btn.addEventListener('click', async function () {
+        const orderId  = this.dataset.orderId;
+        const action   = this.dataset.action;
+        const csrf     = this.dataset.csrf;
+        const card     = document.getElementById('assigned-card-' + orderId);
+        const allBtns  = card.querySelectorAll('.btn-accept, .btn-reject');
+
+        allBtns.forEach(b => { b.disabled = true; });
+        this.innerHTML = action === 'accept'
+            ? '<i class="fa-solid fa-spinner fa-spin"></i> Accepting...'
+            : '<i class="fa-solid fa-spinner fa-spin"></i> Rejecting...';
+
+        try {
+            const fd = new FormData();
+            fd.append('order_id',   orderId);
+            fd.append('action',     action);
+            fd.append('csrf_token', csrf);
+
+            const res  = await fetch('../actions/rider_respond_order.php', { method: 'POST', body: fd });
+            const data = await res.json();
+
+            if (data.success) {
+                card.style.transition = 'all 0.4s ease';
+                card.style.opacity    = '0';
+                card.style.transform  = 'scale(0.95)';
+                setTimeout(() => card.remove(), 400);
+
+                // Show toast
+                showRiderToast(
+                    action === 'accept'
+                        ? '<i class="fa-solid fa-circle-check" style="color:#34c759"></i> ' + data.message
+                        : '<i class="fa-solid fa-circle-xmark" style="color:#ff3b30"></i> ' + data.message,
+                    action === 'accept' ? 'success' : 'error'
+                );
+            } else {
+                allBtns.forEach(b => { b.disabled = false; });
+                showRiderToast('<i class="fa-solid fa-triangle-exclamation"></i> ' + data.message, 'error');
+            }
+        } catch (e) {
+            allBtns.forEach(b => { b.disabled = false; });
+            showRiderToast('<i class="fa-solid fa-triangle-exclamation"></i> Network error. Try again.', 'error');
+        }
+    });
+});
+
+// Rider Toast helper
+function showRiderToast(msg, type) {
+    let toast = document.getElementById('rider-toast');
+    if (!toast) {
+        toast = document.createElement('div');
+        toast.id = 'rider-toast';
+        toast.style.cssText = 'position:fixed;bottom:30px;left:50%;transform:translateX(-50%) translateY(20px);padding:14px 28px;border-radius:999px;font-weight:700;font-size:0.95rem;z-index:10000;opacity:0;transition:all 0.35s;pointer-events:none;white-space:nowrap;box-shadow:0 10px 30px rgba(0,0,0,0.3);color:#fff;';
+        document.body.appendChild(toast);
+    }
+    toast.innerHTML = msg;
+    toast.style.background = type === 'success' ? 'linear-gradient(135deg,#1a7a34,#34c759)' : 'linear-gradient(135deg,#d93025,#ff4136)';
+    toast.style.opacity = '1';
+    toast.style.transform = 'translateX(-50%) translateY(0)';
+    setTimeout(() => {
+        toast.style.opacity = '0';
+        toast.style.transform = 'translateX(-50%) translateY(20px)';
+    }, 4000);
+}
+
 // ── Live Clock ──
 function updateClock() {
     const now = new Date();

--- a/delivery/dashboard.php
+++ b/delivery/dashboard.php
@@ -418,7 +418,7 @@ $activeOrders = $pdo->query("
                                 </a>
                             </div>
                             <div class="field-label" style="margin-top:12px;">Items (<?php echo $order['item_count']; ?>)</div>
-                            <div class="field-value"><?php echo htmlspecialchars(mb_strimwidth($order['item_names'], 0, 60, '...')); ?></div>
+                            <div class="field-value"><?php echo $order['item_names'] !== '' ? htmlspecialchars(mb_strimwidth($order['item_names'], 0, 60, '...')) : '<span style="color:#8b6a44;font-style:italic;">No items recorded</span>'; ?></div>
                         </div>
                         <div class="card-section">
                             <div class="field-label">Delivery Address</div>
@@ -549,7 +549,7 @@ $activeOrders = $pdo->query("
                             </div>
 
                             <div class="field-label" style="margin-top:12px;">Items (<?php echo $order['item_count']; ?>)</div>
-                            <div class="field-value"><?php echo htmlspecialchars(mb_strimwidth($order['item_names'], 0, 60, '...')); ?></div>
+                            <div class="field-value"><?php echo $order['item_names'] !== '' ? htmlspecialchars(mb_strimwidth($order['item_names'], 0, 60, '...')) : '<span style="color:#8b6a44;font-style:italic;">No items recorded</span>'; ?></div>
                         </div>
 
                         <div class="card-section">
@@ -730,9 +730,9 @@ document.querySelectorAll('.location-form').forEach(function(form) {
         navigator.geolocation.getCurrentPosition(function(pos) {
             form.querySelector('[name="delivery_lat"]').value = pos.coords.latitude.toFixed(7);
             form.querySelector('[name="delivery_lng"]').value = pos.coords.longitude.toFixed(7);
-            btn.textContent = '<i class="fa-solid fa-circle-check" style="color:#22c55e"></i> GPS Captured'; btn.disabled = false;
+            btn.innerHTML = '<i class="fa-solid fa-circle-check" style="color:#22c55e"></i> GPS Captured'; btn.disabled = false;
         }, function() {
-            alert('Unable to get location.'); btn.textContent = '<i class="fa-solid fa-location-dot"></i> Use My GPS'; btn.disabled = false;
+            alert('Unable to get location.'); btn.innerHTML = '<i class="fa-solid fa-location-dot"></i> Use My GPS'; btn.disabled = false;
         }, { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 });
     });
 });

--- a/user/order_history.php
+++ b/user/order_history.php
@@ -366,7 +366,7 @@ define('CANCEL_WINDOW_SECONDS', 30 * 60); // 30-minute cancellation window
 
         /* ── Toast Helper ── */
         function showToast(msg, type = '') {
-            toast.textContent  = msg;
+            toast.innerHTML    = msg;
             toast.className    = 'order-toast' + (type ? ' ' + type : '');
             void toast.offsetWidth;
             toast.classList.add('show');


### PR DESCRIPTION
…(GDODS-46, GDODS-51)

GDODS-46 - Rider can accept or reject assigned orders:
- Added 'assigned' status to orders table enum
- Updated rider_assignment_helper.php to set status 'assigned' instead of 'confirmed' and notify the rider
- Created actions/rider_respond_order.php — accept moves to confirmed, reject clears rider and returns to pending with customer notification
- Added New Assignments section in rider dashboard with Accept/Reject buttons wired via AJAX

GDODS-51 - Rider updates delivery status (Picked → On the Way → Delivered):
- Replaced full status dropdown with clean step buttons
- Confirmed/Preparing → 'Mark as Picked Up' (sets out_for_delivery)
- Out for Delivery → 'Mark as Delivered' (sets delivered)
- Each step triggers customer notification via existing update_order_status.php

Also fixed SITE_BASE_URL and htaccess paths from main baseline.