### PR TITLE
fix: correct SITE_BASE_URL to fix HTTP 500 on update_order_status.php

### DIFF
--- a/core/config.php
+++ b/core/config.php
@@ -25,7 +25,7 @@ define('DB_CHARSET', env('DB_CHARSET', 'utf8mb4'));
 // ── Site ───────────────────────────────────────────────────
 define('SITE_NAME',     'SwiftBite');
 define('SITE_TAGLINE',  'Food Delivery, Reinvented');
-define('SITE_BASE_URL', '/food/swiftbite_php_starter'); // no trailing slash
+define('SITE_BASE_URL', '/food'); // no trailing slash
 
 // ── Upload limits ──────────────────────────────────────────
 define('MAX_UPLOAD_MB', 2);


### PR DESCRIPTION
Wrong path /food/swiftbite_php_starter was causing forms and redirects to resolve to non-existent URLs, resulting in HTTP 500 errors. Changed SITE_BASE_URL to /food which matches the actual server path.