### PR TITLE
fix: defer rider assignment for eSewa orders until payment is confirmed

### DIFF
--- a/actions/esewa_success.php
+++ b/actions/esewa_success.php
@@ -21,6 +21,15 @@ if ($responseData && isset($responseData['status']) && $responseData['status'] =
     if ($order && $order['status'] !== 'confirmed') {
         // Officially confirm the order since payment is successful
         $pdo->prepare("UPDATE orders SET status = 'confirmed' WHERE id = ?")->execute([$order['id']]);
+
+        // Assign nearest rider now that payment is confirmed
+        try {
+            include_once('../core/rider_assignment_helper.php');
+            assignNearestRider($pdo, $order['id'], $order['delivery_address']);
+        } catch (Exception $e) {
+            // Non-critical
+        }
+
         header("Location: ../orders/order_confirmation.php?id=" . $order['id'] . "&payment=success");
         exit;
     } else if ($order && $order['status'] === 'confirmed') {

--- a/actions/place_order.php
+++ b/actions/place_order.php
@@ -209,11 +209,15 @@ try {
     $pdo->commit();
 
     // ── GDODS-48: Auto-assign nearest available rider ──
-    try {
-        include_once('../core/rider_assignment_helper.php');
-        assignNearestRider($pdo, $order_id, $address);
-    } catch (Exception $e) {
-        // Non-critical — order still goes through if no rider available
+    // Skip for eSewa: rider assignment is deferred to esewa_success.php after payment is confirmed,
+    // because assignNearestRider sets status='assigned' which breaks the esewa_request.php status='pending' check.
+    if ($payment_method !== 'esewa') {
+        try {
+            include_once('../core/rider_assignment_helper.php');
+            assignNearestRider($pdo, $order_id, $address);
+        } catch (Exception $e) {
+            // Non-critical — order still goes through if no rider available
+        }
     }
 
     // Create notification


### PR DESCRIPTION
assignNearestRider was setting order status to assigned before the eSewa redirect, causing esewa_request.php status check to fail with Invalid order.